### PR TITLE
ET3-52,ET3-62_Additional_user_queries_and_DAO_for_text_materials(papers)

### DIFF
--- a/back-end/src/main/java/com/exadel/team3/backend/dao/PaperRepository.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/dao/PaperRepository.java
@@ -1,0 +1,8 @@
+package com.exadel.team3.backend.dao;
+
+import com.exadel.team3.backend.entities.Paper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PaperRepository extends TaggableRepository<Paper> {
+}

--- a/back-end/src/main/java/com/exadel/team3/backend/dao/StringIdProjection.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/dao/StringIdProjection.java
@@ -1,0 +1,7 @@
+package com.exadel.team3.backend.dao;
+
+import org.bson.types.ObjectId;
+
+public interface StringIdProjection {
+    String getId();
+}

--- a/back-end/src/main/java/com/exadel/team3/backend/dao/UserRepository.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/dao/UserRepository.java
@@ -1,5 +1,6 @@
 package com.exadel.team3.backend.dao;
 
+import com.exadel.team3.backend.entities.UserRole;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -23,4 +24,6 @@ public interface UserRepository extends MongoRepository<User, String>, UserRepos
 
     @Query("{'groups':?0, 'role':'STUDENT'}")
     List<User> findStudentsByGroupName(String group);
+
+    List<User> findByRole(UserRole role);
 }

--- a/back-end/src/main/java/com/exadel/team3/backend/dao/UserRepository.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/dao/UserRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import com.exadel.team3.backend.entities.User;
 
 @Repository
-public interface UserRepository extends MongoRepository<User, String> {
+public interface UserRepository extends MongoRepository<User, String>, UserRepositoryQueries {
     User findByEmail(String email);
 
     List<User> findByEmailIn(Collection<String> emails);

--- a/back-end/src/main/java/com/exadel/team3/backend/dao/UserRepositoryQueries.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/dao/UserRepositoryQueries.java
@@ -1,0 +1,8 @@
+package com.exadel.team3.backend.dao;
+
+import java.util.List;
+
+public interface UserRepositoryQueries {
+    List<String> findStudentsGroups();
+    List<String> findInstitutions();
+}

--- a/back-end/src/main/java/com/exadel/team3/backend/dao/UserRepositoryQueries.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/dao/UserRepositoryQueries.java
@@ -1,8 +1,12 @@
 package com.exadel.team3.backend.dao;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface UserRepositoryQueries {
     List<String> findStudentsGroups();
     List<String> findInstitutions();
+
+    void addGroup(Collection<String> userIds, String groupName);
+    void removeGroup(Collection<String> userIds, String groupName);
 }

--- a/back-end/src/main/java/com/exadel/team3/backend/dao/impl/StringIdProjectionImpl.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/dao/impl/StringIdProjectionImpl.java
@@ -1,11 +1,10 @@
 package com.exadel.team3.backend.dao.impl;
 
 import lombok.Data;
-import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 
 @Data
-class StringIdProjectionObject {
+class StringIdProjectionImpl {
     @Id
     private final String string;
 }

--- a/back-end/src/main/java/com/exadel/team3/backend/dao/impl/StringIdProjectionObject.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/dao/impl/StringIdProjectionObject.java
@@ -1,0 +1,11 @@
+package com.exadel.team3.backend.dao.impl;
+
+import lombok.Data;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+
+@Data
+class StringIdProjectionObject {
+    @Id
+    private final String string;
+}

--- a/back-end/src/main/java/com/exadel/team3/backend/dao/impl/UserRepositoryImpl.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/dao/impl/UserRepositoryImpl.java
@@ -1,12 +1,17 @@
 package com.exadel.team3.backend.dao.impl;
 
 import com.exadel.team3.backend.dao.UserRepositoryQueries;
+import com.exadel.team3.backend.entities.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.*;
 import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.lang.NonNull;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,14 +23,17 @@ public class UserRepositoryImpl implements UserRepositoryQueries {
     public List<String> findStudentsGroups() {
         return mongoTemplate.aggregate(
                 TypedAggregation.newAggregation(
-                    Aggregation.match(Criteria.where("role").is("STUDENT")),
-                    Aggregation.unwind("groups"),
+                    Aggregation.unwind("groups", false),
+                    Aggregation.match(Criteria.where("role").is("STUDENT").and("groups").ne(null)),
                     Aggregation.group("groups"),
                     Aggregation.sort(Sort.Direction.ASC,"groups")
                 ),
                 "users",
-                StringIdProjectionObject.class
-        ).getMappedResults().stream().map(StringIdProjectionObject::getString).collect(Collectors.toList());
+                StringIdProjectionImpl.class
+        ).getMappedResults()
+                .stream()
+                .map(StringIdProjectionImpl::getString)
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -37,8 +45,25 @@ public class UserRepositoryImpl implements UserRepositoryQueries {
                         Aggregation.group("institution")
                 ),
                 "users",
-                StringIdProjectionObject.class
-        ).getMappedResults().stream().map(StringIdProjectionObject::getString).collect(Collectors.toList());
+                StringIdProjectionImpl.class
+        ).getMappedResults()
+                .stream()
+                .map(StringIdProjectionImpl::getString).collect(Collectors.toList());
 
+
+    }
+
+    @Override
+    public void addGroup(@NonNull Collection<String> userIds, @NonNull String groupName) {
+        Query updateQuery = new Query(Criteria.where("email").in(userIds));
+        Update update = new Update().addToSet("groups", groupName);
+        mongoTemplate.updateMulti(updateQuery, update, User.class);
+    }
+
+    @Override
+    public void removeGroup(Collection<String> userIds, String groupName) {
+        Query updateQuery = new Query(Criteria.where("email").in(userIds));
+        Update update = new Update().pull("groups", groupName);
+        mongoTemplate.updateMulti(updateQuery, update, User.class);
     }
 }

--- a/back-end/src/main/java/com/exadel/team3/backend/dao/impl/UserRepositoryImpl.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/dao/impl/UserRepositoryImpl.java
@@ -49,8 +49,6 @@ public class UserRepositoryImpl implements UserRepositoryQueries {
         ).getMappedResults()
                 .stream()
                 .map(StringIdProjectionImpl::getString).collect(Collectors.toList());
-
-
     }
 
     @Override

--- a/back-end/src/main/java/com/exadel/team3/backend/dao/impl/UserRepositoryImpl.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/dao/impl/UserRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.exadel.team3.backend.dao.impl;
+
+import com.exadel.team3.backend.dao.UserRepositoryQueries;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.*;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class UserRepositoryImpl implements UserRepositoryQueries {
+    @Autowired
+    MongoTemplate mongoTemplate;
+
+    @Override
+    public List<String> findStudentsGroups() {
+        return mongoTemplate.aggregate(
+                TypedAggregation.newAggregation(
+                    Aggregation.match(Criteria.where("role").is("STUDENT")),
+                    Aggregation.unwind("groups"),
+                    Aggregation.group("groups"),
+                    Aggregation.sort(Sort.Direction.ASC,"groups")
+                ),
+                "users",
+                StringIdProjectionObject.class
+        ).getMappedResults().stream().map(StringIdProjectionObject::getString).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> findInstitutions() {
+        return mongoTemplate.aggregate(
+                TypedAggregation.newAggregation(
+                        Aggregation.match(Criteria.where("affiliation.institution").ne(null)),
+                        Aggregation.project("affiliation.institution"),
+                        Aggregation.group("institution")
+                ),
+                "users",
+                StringIdProjectionObject.class
+        ).getMappedResults().stream().map(StringIdProjectionObject::getString).collect(Collectors.toList());
+
+    }
+}

--- a/back-end/src/main/java/com/exadel/team3/backend/dto/TestItemDTO.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/dto/TestItemDTO.java
@@ -3,35 +3,17 @@ package com.exadel.team3.backend.dto;
 
 import lombok.*;
 import org.bson.types.ObjectId;
-import org.springframework.util.StringUtils;
 
-import com.exadel.team3.backend.entities.TestItem;
 import com.exadel.team3.backend.entities.TestItemStatus;
 
-public class TestItemDTO extends TestItem {
-    @NonNull
-    @Getter
-    private ObjectId testId;
+@Data
+@AllArgsConstructor
+public class TestItemDTO {
+    private final ObjectId testId;
 
-    public TestItemDTO(ObjectId testId, ObjectId questionId) {
-        this(
-                testId,
-                questionId,
-                null,
-                TestItemStatus.UNANSWERED
-        );
-    }
-    public TestItemDTO(ObjectId testId, ObjectId questionId, String answer) {
-        this(
-                testId,
-                questionId,
-                answer,
-                StringUtils.isEmpty(answer) ? TestItemStatus.UNANSWERED : TestItemStatus.UNCHECKED
-        );
-    }
-    public TestItemDTO(ObjectId testId, ObjectId questionId, String answer, TestItemStatus status) {
-        super(questionId);
-        this.testId = testId;
-        this.setAnswer(answer);
-    }
+    private final ObjectId questionId;
+
+    private final String answer;
+
+    private final TestItemStatus status;
 }

--- a/back-end/src/main/java/com/exadel/team3/backend/dto/TopicDTO.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/dto/TopicDTO.java
@@ -1,0 +1,22 @@
+package com.exadel.team3.backend.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.bson.types.ObjectId;
+import lombok.*;
+
+@Data
+public class TopicDTO {
+    @JsonSerialize(using = ToStringSerializer.class)
+    @JsonProperty("value")
+    private final ObjectId id;
+
+    @JsonProperty("label")
+    private final String text;
+
+    private final List<TopicDTO> children = new ArrayList<>();
+}

--- a/back-end/src/main/java/com/exadel/team3/backend/dto/mappers/TopicDTOMapper.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/dto/mappers/TopicDTOMapper.java
@@ -1,0 +1,34 @@
+package com.exadel.team3.backend.dto.mappers;
+
+import java.util.*;
+import org.springframework.lang.NonNull;
+
+import com.exadel.team3.backend.dto.TopicDTO;
+import com.exadel.team3.backend.entities.Topic;
+
+public class TopicDTOMapper {
+    public static List<TopicDTO> transform(@NonNull List<Topic> topics) {
+        TopicDTO root = new TopicDTO(null, null);
+        topics.forEach(topic -> mergeIntoTopicDTO(root, topic, 0));
+        return root.getChildren();
+    }
+
+    private static void mergeIntoTopicDTO(TopicDTO ceed, Topic candidate, int level) {
+        if (candidate.getParentHierarchy() != null && level < candidate.getParentHierarchy().size()) {
+            Optional<TopicDTO> sibling =
+                    ceed.getChildren()
+                    .stream()
+                    .filter(
+                            tdto ->
+                            tdto.getId().equals(candidate.getParentHierarchy().get(level).getId())
+                    ).findFirst();
+            if (sibling.isPresent()) {
+                mergeIntoTopicDTO(sibling.get(), candidate, level + 1);
+            } else {
+                mergeIntoTopicDTO(ceed, candidate, level + 1);
+            }
+        } else {
+            ceed.getChildren().add(new TopicDTO(candidate.getId(), candidate.getText()));
+        }
+    }
+}

--- a/back-end/src/main/java/com/exadel/team3/backend/entities/Paper.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/entities/Paper.java
@@ -1,0 +1,27 @@
+package com.exadel.team3.backend.entities;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Data
+@Document(collection="papers")
+public class Paper implements Taggable {
+    @Id
+    @JsonSerialize(using = ToStringSerializer.class)
+    @Setter(AccessLevel.NONE)
+    private ObjectId id;
+
+    private String title;
+
+    private String text;
+
+    private List<ObjectId> topicIds;
+}

--- a/back-end/src/main/java/com/exadel/team3/backend/entities/Question.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/entities/Question.java
@@ -1,17 +1,22 @@
 package com.exadel.team3.backend.entities;
 
-import org.bson.types.ObjectId;
-import org.springframework.data.mongodb.core.mapping.Document;
+import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.Setter;
-
-import java.util.List;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 
 @Data
 @Document(collection="questions")
 public class Question implements Taggable {
+    @Id
+    @JsonSerialize(using = ToStringSerializer.class)
     @Setter(AccessLevel.NONE)
     private ObjectId id;
 

--- a/back-end/src/main/java/com/exadel/team3/backend/entities/QuestionStatistics.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/entities/QuestionStatistics.java
@@ -6,14 +6,4 @@ import lombok.Data;
 public class QuestionStatistics {
     private int useCount;
     private int rightAnswersCount;
-/*
-    public QuestionComplexity getRatedComplexity(@NonNull QuestionComplexity defaultComplexity) {
-        if (useCount <= complexityRedefineThreshold) return defaultComplexity;
-        double rightAnswersRatio = rightAnswersCount / useCount;
-
-        if (rightAnswersRatio > 0.75)  return QuestionComplexity.LEVEL_1;
-        if (rightAnswersRatio > 0.5) return QuestionComplexity.LEVEL_2;
-        if (rightAnswersRatio > 0.25) return QuestionComplexity.LEVEL_3;
-        return QuestionComplexity.LEVEL_4;
-    }*/
 }

--- a/back-end/src/main/java/com/exadel/team3/backend/entities/QuestionVariant.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/entities/QuestionVariant.java
@@ -9,5 +9,4 @@ public class QuestionVariant {
     private String text;
 
     private boolean correct;
-
 }

--- a/back-end/src/main/java/com/exadel/team3/backend/entities/Solution.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/entities/Solution.java
@@ -1,21 +1,26 @@
 package com.exadel.team3.backend.entities;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.*;
+
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDateTime;
-import java.util.List;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 
 @Data
 @Document(collection = "solutions")
 public class Solution implements Assignable {
     @Id
+    @JsonSerialize(using = ToStringSerializer.class)
     @Setter(AccessLevel.NONE)
     private ObjectId id;
 
     @NonNull
+    @JsonSerialize(using = ToStringSerializer.class)
     private final ObjectId taskId;
 
     @NonNull

--- a/back-end/src/main/java/com/exadel/team3/backend/entities/Task.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/entities/Task.java
@@ -1,19 +1,22 @@
 package com.exadel.team3.backend.entities;
 
+import java.util.List;
+
 import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NonNull;
 import lombok.Setter;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
-
-import java.util.List;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import lombok.Data;
+import lombok.NonNull;
 
 @Data
 @Document(collection = "tasks")
 public class Task implements Taggable {
     @Id
+    @JsonSerialize(using = ToStringSerializer.class)
     @Setter(AccessLevel.NONE)
     private ObjectId id;
 
@@ -26,7 +29,8 @@ public class Task implements Taggable {
     @NonNull
     private String author;
 
-    private TaskTestingType type = TaskTestingType.PASS_ALL;
+    @NonNull
+    private TaskTestingType type;
 
     private List<ObjectId> topicIds;
 

--- a/back-end/src/main/java/com/exadel/team3/backend/entities/Test.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/entities/Test.java
@@ -1,18 +1,21 @@
 package com.exadel.team3.backend.entities;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import lombok.*;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
-
-import java.time.LocalDateTime;
-import java.util.List;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 
 @Data
 @Document(collection = "tests")
 public class Test implements Assignable {
     @Id
     @Setter(AccessLevel.NONE)
+    @JsonSerialize(using = ToStringSerializer.class)
     private ObjectId id;
 
     @NonNull

--- a/back-end/src/main/java/com/exadel/team3/backend/entities/TestItem.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/entities/TestItem.java
@@ -1,5 +1,7 @@
 package com.exadel.team3.backend.entities;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import lombok.*;
 
 import org.bson.types.ObjectId;
@@ -7,7 +9,9 @@ import org.bson.types.ObjectId;
 @Data
 public class TestItem {
     @NonNull
-    private final ObjectId questionId;
+    @JsonSerialize(using = ToStringSerializer.class)
+    @Setter(AccessLevel.NONE)
+    private ObjectId questionId;
 
     private TestItemStatus status = TestItemStatus.UNANSWERED;
 

--- a/back-end/src/main/java/com/exadel/team3/backend/entities/Topic.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/entities/Topic.java
@@ -1,5 +1,8 @@
 package com.exadel.team3.backend.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import lombok.*;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -10,14 +13,16 @@ import java.util.List;
 @Document(collection = "topics")
 public class Topic {
     @Setter(AccessLevel.NONE)
+    @JsonSerialize(using = ToStringSerializer.class)
     private ObjectId id;
 
     @NonNull
     private String text;
 
+    @JsonSerialize(using = ToStringSerializer.class)
     private ObjectId parentId;
 
-    @Getter(AccessLevel.NONE)
     @Setter(AccessLevel.NONE)
+    @JsonIgnore
     private List<Topic> parentHierarchy;
 }

--- a/back-end/src/main/java/com/exadel/team3/backend/entities/User.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/entities/User.java
@@ -18,8 +18,7 @@ import java.util.Set;
 public class User {
     @Id
     @NonNull
-    @Setter(AccessLevel.NONE)
-    private String email;
+    private final String email;
 
     @NonNull
     private String firstName;

--- a/back-end/src/main/java/com/exadel/team3/backend/entities/User.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/entities/User.java
@@ -7,6 +7,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.util.StringUtils;
 
 import java.util.HashSet;
@@ -35,6 +36,7 @@ public class User {
     @Setter(AccessLevel.NONE)
     private Set<String> groups = new HashSet<>();
 
+    @Field()
     private UserAffiliation affiliation;
 
     private String emailConfirmationCode;

--- a/back-end/src/main/java/com/exadel/team3/backend/entities/User.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/entities/User.java
@@ -35,7 +35,7 @@ public class User {
     @Setter(AccessLevel.NONE)
     private Set<String> groups = new HashSet<>();
 
-    private UserAffiliation education;
+    private UserAffiliation affiliation;
 
     private String emailConfirmationCode;
     public boolean isEmailConfirmed() {

--- a/back-end/src/main/java/com/exadel/team3/backend/entities/UserAffiliation.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/entities/UserAffiliation.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserAffiliation {
     private String institution;
+    private String faculty;
     private int graduationYear;
     private String specialization;
     private String primarySkill;

--- a/back-end/src/main/java/com/exadel/team3/backend/services/DbManagementService.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/services/DbManagementService.java
@@ -1,7 +1,5 @@
 package com.exadel.team3.backend.services;
 
-import org.springframework.stereotype.Service;
-
 public interface DbManagementService {
     void reset();
     void resetAndFillWithSampleData() throws ServiceException;

--- a/back-end/src/main/java/com/exadel/team3/backend/services/PaperService.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/services/PaperService.java
@@ -1,0 +1,7 @@
+package com.exadel.team3.backend.services;
+
+import com.exadel.team3.backend.entities.Paper;
+
+public interface PaperService extends TaggableService<Paper> {
+
+}

--- a/back-end/src/main/java/com/exadel/team3/backend/services/UserService.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/services/UserService.java
@@ -1,6 +1,7 @@
 package com.exadel.team3.backend.services;
 
 import com.exadel.team3.backend.entities.User;
+import com.exadel.team3.backend.entities.UserRole;
 
 import java.util.Collection;
 import java.util.List;
@@ -9,6 +10,8 @@ public interface UserService extends CrudService<User, String>{
     User getPasswordHashAndRole(String email);
 
     List<User> getByGroup(String group);
+
+    List<User> getByRole(UserRole role);
 
     List<String> getGroups();
 

--- a/back-end/src/main/java/com/exadel/team3/backend/services/UserService.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/services/UserService.java
@@ -1,8 +1,8 @@
 package com.exadel.team3.backend.services;
 
 import com.exadel.team3.backend.entities.User;
-import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface UserService extends CrudService<User, String>{
@@ -10,7 +10,13 @@ public interface UserService extends CrudService<User, String>{
 
     List<User> getByGroup(String group);
 
+    List<String> getGroups();
+
+    List<String> getInstitutions();
+
     boolean exists(String email);
 
-    void assignGroup(List<String> emails, String groupId);
+    void assignGroup(Collection<String> userIds, String group);
+    void removeGroup(Collection<String> userIds, String group);
+    void renameGroup(Collection<String> userIds, String oldGroup, String newGroup);
 }

--- a/back-end/src/main/java/com/exadel/team3/backend/services/impl/DbManagementServiceImpl.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/services/impl/DbManagementServiceImpl.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import com.exadel.team3.backend.dao.*;
-import com.exadel.team3.backend.services.ServiceException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -15,13 +13,13 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.exadel.team3.backend.entities.Question;
 import com.exadel.team3.backend.entities.Topic;
 import com.exadel.team3.backend.entities.User;
 import com.exadel.team3.backend.services.DbManagementService;
+import com.exadel.team3.backend.dao.*;
+import com.exadel.team3.backend.entities.Paper;
+import com.exadel.team3.backend.services.ServiceException;
 
 @Service
 @Primary
@@ -39,12 +37,15 @@ public class DbManagementServiceImpl implements DbManagementService {
     @Autowired
     SolutionRepository solutionRepository;
     @Autowired
+    PaperRepository paperRepository;
+    @Autowired
     FileStorage fileStorage;
 
 
     @Override
     public void reset() {
         fileStorage.deleteAll();
+        paperRepository.deleteAll();
         taskRepository.deleteAll();
         solutionRepository.deleteAll();
         testRepository.deleteAll();
@@ -60,6 +61,7 @@ public class DbManagementServiceImpl implements DbManagementService {
         fillCollectionWithSampleData(mapper, userRepository, User.class);
         fillCollectionWithSampleData(mapper, topicRepository, Topic.class);
         fillCollectionWithSampleData(mapper, questionRepository, Question.class);
+        fillCollectionWithSampleData(mapper, paperRepository, Paper.class);
     }
 
     private <T,ID> void fillCollectionWithSampleData(ObjectMapper mapper,

--- a/back-end/src/main/java/com/exadel/team3/backend/services/impl/PaperServiceImpl.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/services/impl/PaperServiceImpl.java
@@ -1,0 +1,22 @@
+package com.exadel.team3.backend.services.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.exadel.team3.backend.dao.PaperRepository;
+import com.exadel.team3.backend.dao.TaggableRepository;
+import com.exadel.team3.backend.entities.Paper;
+import com.exadel.team3.backend.services.PaperService;
+
+@Service
+public class PaperServiceImpl
+        extends TaggableServiceImpl<Paper>
+        implements PaperService {
+    @Autowired
+    PaperRepository paperRepository;
+
+    @Override
+    protected TaggableRepository<Paper> getRepository() {
+        return paperRepository;
+    }
+}

--- a/back-end/src/main/java/com/exadel/team3/backend/services/impl/SolutionCheckerImpl.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/services/impl/SolutionCheckerImpl.java
@@ -54,7 +54,7 @@ class SolutionCheckerImpl implements SolutionChecker {
     }
 
     @Bean
-    private SolutionCheckerRoutine getStubCheckerRoutine() {
+    SolutionCheckerRoutine getStubCheckerRoutine() {
         return ((solution, input, output) -> Math.random()>0.5);
     }
 }

--- a/back-end/src/main/java/com/exadel/team3/backend/services/impl/SolutionServiceImpl.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/services/impl/SolutionServiceImpl.java
@@ -6,7 +6,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.exadel.team3.backend.dao.*;

--- a/back-end/src/main/java/com/exadel/team3/backend/services/impl/TestServiceImpl.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/services/impl/TestServiceImpl.java
@@ -255,7 +255,12 @@ public class TestServiceImpl
                             .filter(item -> item.getStatus() == TestItemStatus.UNCHECKED)
                             .map(
                                     item ->
-                                    new TestItemDTO(test.getId(), item.getQuestionId(), item.getAnswer())
+                                    new TestItemDTO(
+                                            test.getId(),
+                                            item.getQuestionId(),
+                                            item.getAnswer(),
+                                            item.getStatus()
+                                    )
                             )
                 )
                 .collect(Collectors.toList());

--- a/back-end/src/main/java/com/exadel/team3/backend/services/impl/UserServiceImpl.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/services/impl/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.exadel.team3.backend.services.impl;
 import java.util.Collection;
 import java.util.List;
 
+import com.exadel.team3.backend.entities.UserRole;
 import com.exadel.team3.backend.services.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -28,6 +29,11 @@ public class UserServiceImpl
     @Override
     public List<User> getByGroup(@NonNull String group) {
         return userRepository.findStudentsByGroupName(group);
+    }
+
+    @Override
+    public List<User> getByRole(@NonNull UserRole role) {
+        return userRepository.findByRole(role);
     }
 
     @Override

--- a/back-end/src/main/java/com/exadel/team3/backend/services/impl/UserServiceImpl.java
+++ b/back-end/src/main/java/com/exadel/team3/backend/services/impl/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.exadel.team3.backend.services.impl;
 
+import java.util.Collection;
 import java.util.List;
 
 import com.exadel.team3.backend.services.UserService;
@@ -30,6 +31,16 @@ public class UserServiceImpl
     }
 
     @Override
+    public List<String> getGroups() {
+        return userRepository.findStudentsGroups();
+    }
+
+    @Override
+    public List<String> getInstitutions() {
+        return userRepository.findInstitutions();
+    }
+
+    @Override
     public User getPasswordHashAndRole(@NonNull String email) {
         return userRepository.findPasswordHashAndRole(email);
     }
@@ -40,13 +51,21 @@ public class UserServiceImpl
     }
 
     @Override
-    public void assignGroup(@NonNull List<String> emails, @NonNull String group) {
-        List<User> matchedUsers = userRepository.findByEmailIn(emails);
-        for (User user : matchedUsers) {
-            user.getGroups().add(group);
-        }
-        userRepository.saveAll(matchedUsers);
+    public void assignGroup(@NonNull Collection<String> userIds, @NonNull String group) {
+        userRepository.addGroup(userIds, group);
     }
+
+    @Override
+    public void renameGroup(Collection<String> userIds, @NonNull String oldGroup, @NonNull String newGroup) {
+        userRepository.removeGroup(userIds, oldGroup);
+        userRepository.addGroup(userIds, newGroup);
+    }
+
+    @Override
+    public void removeGroup(Collection<String> userIds, String group) {
+        userRepository.removeGroup(userIds, group);
+    }
+
 
 
 }

--- a/back-end/src/main/resources/json/sample-papers.json
+++ b/back-end/src/main/resources/json/sample-papers.json
@@ -1,0 +1,19 @@
+[
+  {
+    "title":"Учебник по Java для начинающих",
+    "text":"<a href='http://proglang.su/java/'>Учебный материал доступен по данной ссылке</a>",
+    "topicIds":[
+      "5b4898d987ae4314d278f38d",
+      "5b4898d987ae4314d278f38f"
+    ]
+  },
+  {
+    "title":"Руководство по программированию на C#",
+    "text":"<a href='https://docs.microsoft.com/ru-ru/dotnet/csharp/programming-guide/'>Ознакомиться с руководством можно по данной ссылке</a>",
+    "topicIds":[
+      "5b4898d987ae4314d278f38d",
+      "5b4898d987ae4314d278f390"
+    ]
+  }
+]
+

--- a/back-end/src/main/resources/json/sample-users.json
+++ b/back-end/src/main/resources/json/sample-users.json
@@ -5,9 +5,10 @@
     "lastName":"Конь",
     "role":"STUDENT",
     "passwordHash":"$2a$10$GqE6IY43930ceftcqRrFdOwz/y8mT7L/H7UxRgu9ntsEtNccsimLO",
-    "groups":["Первая группа"],
-    "education":{
+    "groups":["Первая группа","Первая запасная группа"],
+    "affiliation":{
       "institution":"БГУ",
+      "faculty":"ФПМИ",
       "graduationYear":"2019",
       "specialization":"Прикладная информатика",
       "primarySkill":"Java"
@@ -21,8 +22,9 @@
     "role":"STUDENT",
     "passwordHash":"$2a$10$GqE6IY43930ceftcqRrFdOwz/y8mT7L/H7UxRgu9ntsEtNccsimLO",
     "groups":["Первая группа"],
-    "education":{
+    "affiliation":{
       "institution":"БГУ",
+      "faculty":"ФПМИ",
       "graduationYear":"2019",
       "specialization":"Прикладная информатика",
       "primarySkill":"Java"
@@ -44,7 +46,11 @@
     "lastName":"Плюшкина",
     "role":"TEACHER",
     "passwordHash":"$2a$10$GqE6IY43930ceftcqRrFdOwz/y8mT7L/H7UxRgu9ntsEtNccsimLO",
-    "groups":["Первая группа"]
+    "groups":["Первая группа"],
+    "affiliation":{
+      "institution":"БГУ",
+      "faculty":"ФПМИ"
+    }
   },
 
   {
@@ -53,7 +59,11 @@
     "lastName":"Кот",
     "role":"TEACHER",
     "passwordHash":"$2a$10$GqE6IY43930ceftcqRrFdOwz/y8mT7L/H7UxRgu9ntsEtNccsimLO",
-    "groups":["Первая группа","Вторая группа"]
+    "groups":["Первая группа","Вторая группа"],
+    "affiliation":{
+      "institution":"БГУ",
+      "faculty":"ФПМИ"
+    }
   },
 
   {
@@ -63,8 +73,9 @@
     "role":"STUDENT",
     "passwordHash":"$2a$10$GqE6IY43930ceftcqRrFdOwz/y8mT7L/H7UxRgu9ntsEtNccsimLO",
     "groups":["Первая группа"],
-    "education":{
+    "affiliation":{
       "institution":"БГУ",
+      "faculty":"ФПМИ",
       "graduationYear":"2020",
       "specialization":"Актуарная математика",
       "primarySkill":"C#"
@@ -78,8 +89,9 @@
     "role":"STUDENT",
     "passwordHash":"$2a$10$GqE6IY43930ceftcqRrFdOwz/y8mT7L/H7UxRgu9ntsEtNccsimLO",
     "groups":["Вторая группа"],
-    "education":{
+    "affiliation":{
       "institution":"БГУ",
+      "faculty":"ФПМИ",
       "graduationYear":"2020",
       "specialization":"Актуарная математика",
       "primarySkill":"Assembler"
@@ -93,11 +105,12 @@
     "role":"STUDENT",
     "passwordHash":"$2a$10$GqE6IY43930ceftcqRrFdOwz/y8mT7L/H7UxRgu9ntsEtNccsimLO",
     "groups":["Вторая группа"],
-    "education":{
+    "affiliation":{
       "institution":"БГУ",
+      "faculty":"Филфак",
       "graduationYear":"2021",
       "specialization":"Романская филология",
-      "primarySkill":"Java"
+      "primarySkill":"Фортран"
     }
   },
 
@@ -108,8 +121,9 @@
     "role":"STUDENT",
     "passwordHash":"$2a$10$GqE6IY43930ceftcqRrFdOwz/y8mT7L/H7UxRgu9ntsEtNccsimLO",
     "groups":["Первая группа"],
-    "education":{
-      "institution":"БГУ",
+    "affiliation":{
+      "institution":"БГУИР",
+      "faculty":"ФКСС",
       "graduationYear":"2020",
       "specialization":"Компьютерная безопасность",
       "primarySkill":"Python"
@@ -123,8 +137,9 @@
     "role":"STUDENT",
     "passwordHash":"$2a$10$GqE6IY43930ceftcqRrFdOwz/y8mT7L/H7UxRgu9ntsEtNccsimLO",
     "groups":["Вторая группа"],
-    "education":{
-      "institution":"БГУ",
+    "affiliation":{
+      "institution":"БГУИР",
+      "faculty":"ФКСС",
       "graduationYear":"2020",
       "specialization":"Компьютерная безопасность",
       "primarySkill":"С++"

--- a/back-end/src/main/resources/json/sample-users.json
+++ b/back-end/src/main/resources/json/sample-users.json
@@ -36,7 +36,7 @@
     "firstName":"Макар",
     "lastName":"Свирепый",
     "role":"ADMIN",
-    "passwordHash":"$2a$10$GqE6IY43930ceftcqRrFdOwz/y8mT7L/H7UxRgu9ntsEtNccsimLO",
+    "passwordHash":"$2a$10$0vYSCnti0LwCOchxGbfab.BNsJkKUq9fj7lsX7f/D8xdiYqcGRUC2",
     "groups":[]
   },
 
@@ -45,7 +45,7 @@
     "firstName":"Леокадия",
     "lastName":"Плюшкина",
     "role":"TEACHER",
-    "passwordHash":"$2a$10$GqE6IY43930ceftcqRrFdOwz/y8mT7L/H7UxRgu9ntsEtNccsimLO",
+    "passwordHash":"$2a$10$bna/Cb9DI0gktn1L16Ltu.UIY0zm.HB9Phq.mwoedTu4RX1GbJioC",
     "groups":["Первая группа"],
     "affiliation":{
       "institution":"БГУ",
@@ -103,7 +103,7 @@
     "firstName":"Анна-Мария",
     "lastName":"Акулич",
     "role":"STUDENT",
-    "passwordHash":"$2a$10$GqE6IY43930ceftcqRrFdOwz/y8mT7L/H7UxRgu9ntsEtNccsimLO",
+    "passwordHash":"$2a$10$X8SQVka14m.WGbefQNdz6OhN7ormP938hWnkQvp2RkILrPDy0fdT2",
     "groups":["Вторая группа"],
     "affiliation":{
       "institution":"БГУ",


### PR DESCRIPTION
Updated User repository and services for querying for lists of institutions and groups.
Implemented group removal and renaming via UserService
Updated User entity in accordance with tech specs
Created entity, dao and service for papers (texts to be displayed to students, etc.)
++ TopicDTO object for easy conversion to json (bears collection of  nested DTO objects), and a mapper class 